### PR TITLE
fix: Actually maybe publish this time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 
 from setuptools import find_namespace_packages, setup
 
+
 with open(os.path.join("VERSION")) as f:
     version = f.read().strip()
 


### PR DESCRIPTION
It turns out clicking Update Selection is not sufficient to change which
repos have access to an org secret; you also need to click a separate
Save button.