### PR TITLE
Add `codelists check` command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,10 @@ on: [push]
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019]
+    runs-on: ${{ matrix.os }}
     name: Run test suite
     steps:
     - name: Checkout

--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -1,9 +1,17 @@
+import datetime
+import hashlib
+import json
 from pathlib import Path
+import sys
 
 from opensafely._vendor import requests
 
 
 DESCRIPTION = "Commands for interacting with https://codelists.opensafely.org/"
+
+CODELISTS_DIR = "codelists"
+CODELISTS_FILE = "codelists.txt"
+MANIFEST_FILE = "codelists.json"
 
 
 def add_arguments(parser):
@@ -18,7 +26,10 @@ def add_arguments(parser):
     )
     parser_update = subparsers.add_parser(
         "update",
-        help="Update codelists, using specification at codelists/codelists.txt",
+        help=(
+            f"Update codelists, using specification at "
+            f"{CODELISTS_DIR}/{CODELISTS_FILE}"
+        ),
     )
     parser_update.set_defaults(function=update)
 
@@ -31,26 +42,74 @@ def main():
 
 
 def update():
-    codelists_path = Path.cwd() / "codelists"
+    codelists_path = Path.cwd() / CODELISTS_DIR
+    if not codelists_path.exists() or not codelists_path.is_dir():
+        exit_with_error(f"No '{CODELISTS_DIR}' folder found")
+    codelists_file = codelists_path / CODELISTS_FILE
+    if not codelists_file.exists():
+        exit_with_error(f"No file found at '{CODELISTS_DIR}/{CODELISTS_FILE}'")
     old_files = set(codelists_path.glob("*.csv"))
     new_files = set()
-    lines = codelists_path.joinpath("codelists.txt").read_text().splitlines()
+    lines = codelists_file.read_text().splitlines()
+    manifest = {"files": {}}
     for line in lines:
         line = line.strip()
         if not line or line.startswith("#"):
             continue
         print(f"Fetching {line}")
         project_id, codelist_id, version = line.split("/")
-        url = (
+        codelist_url = (
             f"https://codelists.opensafely.org"
-            f"/codelist/{project_id}/{codelist_id}/{version}/download.csv"
+            f"/codelist/{project_id}/{codelist_id}/{version}/"
         )
+        download_url = f"{codelist_url}download.csv"
         codelist_file = codelists_path / f"{project_id}-{codelist_id}.csv"
-
-        response = requests.get(url)
-        response.raise_for_status()
+        try:
+            response = requests.get(download_url)
+            response.raise_for_status()
+        except Exception as e:
+            exit_with_error(
+                f"Error downloading codelist: {e}\n\n"
+                f"Check that you can access the codelist at:\n{codelist_url}"
+            )
         codelist_file.write_bytes(response.content)
         new_files.add(codelist_file)
+        key = str(codelist_file.relative_to(codelists_path))
+        manifest["files"][key] = {
+            "url": codelist_url,
+            "downloaded_at": f"{datetime.datetime.utcnow()}Z",
+            "sha": hash_bytes(response.content),
+        }
+    manifest_file = codelists_path / MANIFEST_FILE
+    preserve_download_dates(manifest, manifest_file)
+    manifest_file.write_text(json.dumps(manifest, indent=2))
     for file in old_files - new_files:
         print(f"Deleting {file.name}")
         file.unlink()
+
+
+def preserve_download_dates(manifest, old_manifest_file):
+    """
+    If file contents are unchanged then we copy the original download date from
+    the existing manifest. This makes the update process idempotent and
+    prevents unnecessary diff noise.
+    """
+    if not old_manifest_file.exists():
+        return
+    old_manifest = json.loads(old_manifest_file.read_text())
+    for filename, details in manifest["files"].items():
+        old_details = old_manifest["files"].get(filename)
+        if old_details and old_details["sha"] == details["sha"]:
+            details["downloaded_at"] = old_details["downloaded_at"]
+
+
+def hash_bytes(content):
+    # Normalize line-endings. Windows in general, and git on Windows in
+    # particular, is prone to messing about with these
+    content = b"\n".join(content.splitlines())
+    return hashlib.sha1(content).hexdigest()
+
+
+def exit_with_error(message):
+    print(message)
+    sys.exit(1)

--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -37,7 +37,7 @@ def update():
     lines = codelists_path.joinpath("codelists.txt").read_text().splitlines()
     for line in lines:
         line = line.strip()
-        if not line:
+        if not line or line.startswith("#"):
             continue
         print(f"Fetching {line}")
         project_id, codelist_id, version = line.split("/")

--- a/tests/fixtures/codelists/codelists.json
+++ b/tests/fixtures/codelists/codelists.json
@@ -1,16 +1,19 @@
 {
   "files": {
     "opensafely-covid-identification.csv": {
+      "id": "opensafely/covid-identification/2020-06-03",
       "url": "https://codelists.opensafely.org/codelist/opensafely/covid-identification/2020-06-03/",
       "downloaded_at": "2020-12-18 16:53:23.436542Z",
       "sha": "124db6929439379b7dacd55ba26ae4f2ed9370bc"
     },
     "opensafely-chronic-respiratory-disease.csv": {
+      "id": "opensafely/chronic-respiratory-disease/2020-04-10",
       "url": "https://codelists.opensafely.org/codelist/opensafely/chronic-respiratory-disease/2020-04-10/",
       "downloaded_at": "2020-12-18 16:53:23.557340Z",
       "sha": "77946d9b844f348daf5c8c9e81346b9776d13998"
     },
     "opensafely-current-asthma.csv": {
+      "id": "opensafely/current-asthma/2020-05-06",
       "url": "https://codelists.opensafely.org/codelist/opensafely/current-asthma/2020-05-06/",
       "downloaded_at": "2020-12-18 16:53:23.649007Z",
       "sha": "1bd6c0cd0553edb334f7efc860d06c8f18fc6d50"

--- a/tests/fixtures/codelists/codelists.json
+++ b/tests/fixtures/codelists/codelists.json
@@ -1,0 +1,19 @@
+{
+  "files": {
+    "opensafely-covid-identification.csv": {
+      "url": "https://codelists.opensafely.org/codelist/opensafely/covid-identification/2020-06-03/",
+      "downloaded_at": "2020-12-18 16:53:23.436542Z",
+      "sha": "124db6929439379b7dacd55ba26ae4f2ed9370bc"
+    },
+    "opensafely-chronic-respiratory-disease.csv": {
+      "url": "https://codelists.opensafely.org/codelist/opensafely/chronic-respiratory-disease/2020-04-10/",
+      "downloaded_at": "2020-12-18 16:53:23.557340Z",
+      "sha": "77946d9b844f348daf5c8c9e81346b9776d13998"
+    },
+    "opensafely-current-asthma.csv": {
+      "url": "https://codelists.opensafely.org/codelist/opensafely/current-asthma/2020-05-06/",
+      "downloaded_at": "2020-12-18 16:53:23.649007Z",
+      "sha": "1bd6c0cd0553edb334f7efc860d06c8f18fc6d50"
+    }
+  }
+}

--- a/tests/fixtures/codelists/codelists.txt
+++ b/tests/fixtures/codelists/codelists.txt
@@ -1,0 +1,3 @@
+opensafely/covid-identification/2020-06-03
+opensafely/chronic-respiratory-disease/2020-04-10
+opensafely/current-asthma/2020-05-06

--- a/tests/fixtures/codelists/opensafely-chronic-respiratory-disease.csv
+++ b/tests/fixtures/codelists/opensafely-chronic-respiratory-disease.csv
@@ -1,0 +1,413 @@
+CTV3ID,CTV3PreferredTermDesc,CTV3Source
+23E5.,O/E - fibrosis of lung present,High_Level_SNOMED
+663K.,Airways obstructn irreversible,CTV3Map_Code_And_Term
+7450.,Lung transplant,CTV3Map_Code_And_Term
+7450y,Other specified transplantation of lung,CTV3Map_Code_And_Term
+7450z,Transplantation of lung NOS,CTV3Map_Code_And_Term
+A114.,Tuberculous fibrosis of lung,High_Level_SNOMED
+A115.,Tuberculous bronchiectasis,CTV3Map_Code_And_Term
+A7899,HIV disease resulting in lymphoid interstitial pneumonitis,CTV3_Children
+AD52.,Sarcoidosis of lung with sarcoidosis of lymph nodes,CTV3Map_Code_And_Term
+C370.,Cystic fibrosis,CTV3Map_Code_And_Term
+C370.,Cystic fibrosis,CTV3Map_Code_Only
+C3700,Cystic fibrosis with no meconium ileus,CTV3Map_Code_And_Term
+C3701,Meconium ileus in cystic fibrosis,CTV3Map_Code_And_Term
+C3701,Meconium ileus in cystic fibrosis,CTV3Map_Code_Only
+C3702,Cystic fibrosis with pulmonary manifestations,CTV3Map_Code_And_Term
+C3703,Cystic fibrosis with intestinal manifestations,CTV3Map_Code_And_Term
+C370z,Cystic fibrosis NOS,CTV3Map_Code_And_Term
+H0614,Obliterating fibrous bronchiolitis,QOF
+H3...,Chronic obstructive lung disease,CTV3Map_Code_And_Term
+H3...,Chronic obstructive lung disease,CTV3Map_Code_Only
+H31..,Chronic bronchitis,CTV3Map_Code_And_Term
+H310.,Simple chronic bronchitis,CTV3Map_Code_And_Term
+H3100,Simple chronic bronchitis,CTV3_Children
+H310z,Simple chronic bronchitis NOS,CTV3Map_Code_And_Term
+H311.,Mucopurulent chronic bronchitis,CTV3Map_Code_And_Term
+H3110,Purulent chronic bronchitis,CTV3_Children
+H311z,Mucopurulent chronic bronchitis NOS,CTV3Map_Code_And_Term
+H3121,Emphysematous bronchitis,CTV3Map_Code_And_Term
+H3122,Acute exacerbation of chronic obstructive airways disease,CTV3Map_Code_And_Term
+H312z,Obstructive chronic bronchitis NOS,CTV3Map_Code_And_Term
+H313.,Mixed simple and mucopurulent chronic bronchitis,CTV3Map_Code_And_Term
+H31y.,Other chronic bronchitis,CTV3Map_Code_And_Term
+H31y0,Chronic tracheitis,QOF
+H31y1,Chronic tracheobronchitis,CTV3Map_Code_And_Term
+H31yz,Other chronic bronchitis NOS,CTV3Map_Code_And_Term
+H31z.,Chronic bronchitis NOS,CTV3Map_Code_And_Term
+H32..,Emphysema,CTV3Map_Code_And_Term
+H320.,Chronic bullous emphysema,CTV3Map_Code_And_Term
+H3200,Segmental bullous emphysema,CTV3Map_Code_And_Term
+H3201,Zonal bullous emphysema,CTV3Map_Code_And_Term
+H3202,Giant bullous emphysema,CTV3Map_Code_And_Term
+H3203,(Bullous emphysema with collapse) or (tension pneumatocoele),High_Level_SNOMED
+H320z,Chronic bullous emphysema NOS,CTV3Map_Code_And_Term
+H321.,Panlobular emphysema,CTV3Map_Code_And_Term
+H322.,Centrilobular emphysema,CTV3Map_Code_And_Term
+H32y.,Other emphysema,CTV3Map_Code_And_Term
+H32y0,Acute vesicular emphysema,CTV3Map_Code_And_Term
+H32y1,Emphysema: [acute interstitial] or [atrophic - senile],QOF
+H32y2,MacLeods syndrome,CTV3Map_Code_And_Term
+H32y2,MacLeods syndrome,CTV3Map_Code_Only
+H32yz,(Sawyer-Jones syndrome) or (other emphysema NOS),CTV3_Children
+H32z.,Emphysema NOS,CTV3Map_Code_And_Term
+H34..,Bronchiectasis,CTV3Map_Code_And_Term
+H340.,Recurrent bronchiectasis,CTV3Map_Code_And_Term
+H341.,Post-infective bronchiectasis,CTV3Map_Code_And_Term
+H34z.,Bronchiectasis NOS,CTV3Map_Code_And_Term
+H35..,Extrinsic allergic alveolitis,CTV3Map_Code_And_Term
+H35..,Extrinsic allergic alveolitis,CTV3Map_Code_Only
+H350.,Farmers' lung,CTV3Map_Code_And_Term
+H351.,Bagassosis,CTV3Map_Code_And_Term
+H352.,Bird-fancier's lung,CTV3Map_Code_And_Term
+H3520,Budgerigar-fanciers' lung,CTV3Map_Code_And_Term
+H3521,Pigeon-fanciers' lung,CTV3Map_Code_And_Term
+H352z,Bird-fancier's lung NOS,CTV3Map_Code_And_Term
+H353.,Cork-handlers' lung,CTV3Map_Code_And_Term
+H354.,Malt workers' lung,CTV3Map_Code_And_Term
+H355.,Mushroom workers' lung,CTV3Map_Code_And_Term
+H356.,Maple bark strippers' lung,CTV3Map_Code_And_Term
+H357.,Ventilation pneumonitis,CTV3Map_Code_And_Term
+H35y.,Other allergic alveolitis,CTV3Map_Code_And_Term
+H35y0,Cheese-washers' lung,CTV3Map_Code_And_Term
+H35y1,Coffee-workers' lung,CTV3Map_Code_And_Term
+H35y2,Fish-meal workers' lung,CTV3Map_Code_And_Term
+H35y3,Furriers' lung,CTV3_Children
+H35y4,Grain-handlers' disease,CTV3_Children
+H35y5,Pituitary snuff-takers' disease,CTV3Map_Code_And_Term
+H35y6,Sequoiosis,CTV3Map_Code_And_Term
+H35y7,Wood pulp workers' lung,CTV3_Children
+H35y8,Air-conditioner and humidifier lung,CTV3Map_Code_And_Term
+H35yz,Other allergic alveolitis NOS,CTV3Map_Code_And_Term
+H35z.,Allergic alveolitis and pneumonitis NOS,CTV3Map_Code_And_Term
+H35z0,Allergic extrinsic alveolitis NOS,CTV3Map_Code_And_Term
+H35z1,Hypersensitivity pneumonitis NOS,CTV3Map_Code_And_Term
+H3y..,Other specified chronic obstructive airways disease,CTV3Map_Code_And_Term
+H3y..,Other specified chronic obstructive airways disease,CTV3Map_Code_Only
+H3y0.,Chronic obstruct pulmonary dis with acute lower resp infectn,CTV3Map_Code_And_Term
+H3y1.,"Chron obstruct pulmonary dis wth acute exacerbation, unspec",CTV3_Children
+H3z..,Chronic obstructive airways disease NOS,CTV3Map_Code_And_Term
+H3z..,Chronic obstructive airways disease NOS,CTV3Map_Code_Only
+H4...,Lung dis: [pneumoconioses] or [occup] or [due extern agent],CTV3_Children
+H40..,Coal workers' pneumoconiosis,CTV3Map_Code_And_Term
+H41..,Asbestos pneumoconiosis,CTV3Map_Code_And_Term
+H41z.,Asbestosis NOS,CTV3Map_Code_And_Term
+H42..,Silicosis,CTV3Map_Code_And_Term
+H420.,Talc pneumoconiosis,CTV3Map_Code_And_Term
+H421.,Simple silicosis,CTV3Map_Code_And_Term
+H422.,Complicated silicosis,CTV3Map_Code_And_Term
+H423.,Massive silicotic fibrosis,CTV3Map_Code_And_Term
+H42z.,Silica pneumoconiosis NOS,CTV3Map_Code_And_Term
+H43..,Pneumoconiosis due to other inorganic dust,CTV3Map_Code_And_Term
+H430.,Aluminium lung,CTV3_Children
+H431.,Bauxite pneumoconiosis,CTV3Map_Code_And_Term
+H432.,Berylliosis,CTV3Map_Code_And_Term
+H433.,Graphite pneumoconiosis,CTV3Map_Code_And_Term
+H434.,Iron pneumoconiosis,CTV3Map_Code_And_Term
+H435.,Tin pneumoconiosis,CTV3Map_Code_And_Term
+H43z.,Pneumoconiosis due to inorganic dust NOS,CTV3Map_Code_And_Term
+H44..,Pneumopathy due to inhalation of other dust,CTV3Map_Code_And_Term
+H440.,Byssinosis,CTV3Map_Code_And_Term
+H441.,Cannabinosis,CTV3Map_Code_And_Term
+H44z.,Pneumopathy due to inhalation of other dust NOS,CTV3Map_Code_And_Term
+H45..,Pneumoconiosis NOS,CTV3Map_Code_And_Term
+H450.,Pneumoconiosis associated with tuberculosis,CTV3Map_Code_And_Term
+H460.,Bronchitis and pneumonitis due to chemical fumes,High_Level_SNOMED
+H4601,Acute pneumonitis due to chemical fumes,High_Level_SNOMED
+H460z,Bronchitis and pneumonitis due to chemical fumes NOS,High_Level_SNOMED
+H464.,Chronic respiratory conditions due to chemical fumes,CTV3Map_Code_And_Term
+H4640,Chronic emphysema due to chemical fumes,CTV3Map_Code_And_Term
+H4641,Toxic bronchiolitis obliterans,CTV3Map_Code_And_Term
+H4642,Chronic pulmonary fibrosis due to chemical fumes,CTV3Map_Code_And_Term
+H464z,Chronic respiratory conditions due to chemical fumes NOS,CTV3Map_Code_And_Term
+H46z0,Silo-fillers' disease,High_Level_SNOMED
+H47..,Aspiration pneumonitis,High_Level_SNOMED
+H4y0.,Acute pulmonary radiation disease,High_Level_SNOMED
+H4y00,Acute radiation pneumonitis,High_Level_SNOMED
+H4y0z,Acute pulmonary radiation disease NOS,High_Level_SNOMED
+H4y1.,Chronic pulmonary radiation disease,CTV3Map_Code_And_Term
+H4y10,Radiation-induced diffuse interstitial pulmonary fibrosis,CTV3Map_Code_And_Term
+H4y1z,Chronic pulmonary radiation disease NOS,CTV3Map_Code_And_Term
+H4y2.,Drug-induced interstitial lung disorders,CTV3Map_Code_And_Term
+H4y20,Acute drug-induced interstitial lung disorders,CTV3_Children
+H4y21,Chronic drug-induced interstitial lung disorders,CTV3Map_Code_And_Term
+H52y1,Persistent pneumothorax,QOF
+H5302,Gangrenous pneumonia,High_Level_SNOMED
+H5410,Chronic pulmonary oedema,CTV3Map_Code_And_Term
+H55..,Lung: [cirrhosis of] or [postinflamm pulmonary fibrosis],CTV3_Children
+H561.,Idiopathic pulmonary haemosiderosis,CTV3Map_Code_And_Term
+H563.,(Fibros alveolitis: [idiopath][cryptog]) or (Hamm-Rich synd),CTV3_Children
+H5631,Diffuse interstitial pulmonary fibrosis,CTV3Map_Code_And_Term
+H563z,Idiopathic fibrosing alveolitis NOS,CTV3Map_Code_And_Term
+H56y0,Endogenous lipoid pneumonia,High_Level_SNOMED
+H571.,Rheumatic pneumonia,CTV3Map_Code_And_Term
+H572.,Lung disease with systemic sclerosis,CTV3Map_Code_And_Term
+H57y0,Pulmonary amyloidosis,CTV3Map_Code_And_Term
+H57y1,Lung disease with polymyositis,CTV3Map_Code_And_Term
+H57y2,Pulmonary sarcoidosis,CTV3Map_Code_And_Term
+H57y3,Lung disease with Sjogren's disease,CTV3Map_Code_And_Term
+H57y4,Lung disease with systemic lupus erythematosus,CTV3Map_Code_And_Term
+H581.,(Emphysema [interstitial]/[mediastinal])/(pneumomediastinum),High_Level_SNOMED
+H582.,Compensatory emphysema,CTV3Map_Code_And_Term
+H583.,Pulmonary eosinophilia,High_Level_SNOMED
+H591.,Chronic respiratory failure,CTV3Map_Code_And_Term
+Hy02.,Chronic pulmonary insufficiency following surgery,CTV3Map_Code_And_Term
+Hyu30,[X]Other emphysema,CTV3Map_Code_And_Term
+Hyu31,[X]Other specified chronic obstructive pulmonary disease,CTV3Map_Code_And_Term
+Hyu40,[X]Pneumoconiosis due to other dust containing silica,CTV3Map_Code_And_Term
+Hyu41,[X]Pneumoconiosis due to other specified inorganic dusts,CTV3_Children
+Hyu43,[X]Hypersensitivity pneumonitis due to other organic dusts,CTV3_Children
+Hyu47,[X]Pneumonitis due to inhalation of other solids and liquids,High_Level_SNOMED
+Hyu50,[X]Other interstitial pulmonary diseases with fibrosis,CTV3Map_Code_And_Term
+K260.,(Azoospermia) or (Young's syndrome),High_Level_SNOMED
+L380.,(Obstet anaesth + pulm complications) or (Mendelson's syndr),High_Level_SNOMED
+N0421,Rheumatoid lung,CTV3Map_Code_And_Term
+N0421,Rheumatoid lung,CTV3Map_Code_Only
+N04y0,(Rheum lung) or (Caplan synd) or (fibr alveolit assoc arthr),High_Level_SNOMED
+P851.,Pulmonary hypoplasia,CTV3_Children
+P861.,Congenital bronchiectasis,CTV3Map_Code_And_Term
+PK35.,Kartageners syndrome,High_Level_SNOMED
+Q317.,Neonatal chronic respiratory disease,CTV3Map_Code_And_Term
+Q3170,Bronchopulmonary dysplasia,CTV3Map_Code_And_Term
+Q3171,Prematurity with interstitial pulmonary fibrosis,CTV3Map_Code_And_Term
+Q3172,Pulmonary dysmaturity,CTV3Map_Code_And_Term
+Q317z,Perinatal chronic respiratory disease NOS,CTV3Map_Code_And_Term
+Qyu36,[X]Other chronic resp diseases originating/perinatal period,CTV3_Children
+SP130,Mendelson's syndrome as a complication of care,High_Level_SNOMED
+SP131,Other aspiration pneumonia as a complication of care,High_Level_SNOMED
+X00s1,Single lung transplant,CTV3Map_Code_And_Term
+X00s2,Double lung transplant,CTV3Map_Code_And_Term
+X00s3,Double lung transplant as a block,CTV3_Children
+X00s4,Bilateral sequential single lung transplant,CTV3_Children
+X100V,Chronic pulmonary coccidioidomycosis,QOF
+X100l,Congenital cystic bronchiectasis,CTV3_Children
+X100m,Acquired bronchiectasis,CTV3_Children
+X100n,Idiopathic bronchiectasis,CTV3_Children
+X100o,Obstructive bronchiectasis,CTV3_Children
+X100p,Toxin-induced bronchiectasis,CTV3_Children
+X100q,Bronchiectasis due to toxic aspiration,CTV3_Children
+X100r,Bronchiectasis due to toxic inhalation,CTV3_Children
+X100t,Post-lung transplantation bronchiectasis,CTV3_Children
+X101U,Asbestos-induced pleural plaque,CTV3Map_Code_And_Term
+X101U,Asbestos-induced pleural plaque,CTV3Map_Code_Only
+X101X,Inherited mucociliary clearance defect,High_Level_SNOMED
+X101Z,Primary ciliary dyskinesia,High_Level_SNOMED
+X101a,Primary ciliary dyskinesia - transposn ciliary microtubules,High_Level_SNOMED
+X101b,Immotile cilia syndrome due to defective radial spokes,High_Level_SNOMED
+X101c,Immotile cilia syndrome due to excessively long cilia,High_Level_SNOMED
+X101d,Young's syndrome,QOF
+X101e,Rutland ciliary disorientation syndrome,High_Level_SNOMED
+X101i,"Chron obstruct pulmonary dis wth acute exacerbation, unspec",CTV3Map_Code_And_Term
+X101j,Occupational chronic bronchitis,CTV3_Children
+X101k,Byssinosis grade 3,CTV3_Children
+X101l,Bronchiolitis obliterans,CTV3Map_Code_And_Term
+X101m,Drug-induced bronchiolitis obliterans,CTV3_Children
+X101n,Pulmonary emphysema,CTV3_Children
+X101o,Pulmonary emphysema in alpha-1 PI deficiency,CTV3_Children
+X101p,Toxic emphysema,CTV3_Children
+X101q,Congenital lobar emphysema,CTV3_Children
+X101r,Scar emphysema,CTV3_Children
+X102B,Mill fever,CTV3_Children
+X102H,Cryptogenic pulmonary eosinophilia,High_Level_SNOMED
+X102J,Animal handlers' lung,CTV3_Children
+X102K,Dog house disease,CTV3_Children
+X102L,Dry rot lung,CTV3_Children
+X102M,Lycoperdonosis,CTV3_Children
+X102N,Wheat weevil disease,CTV3_Children
+X102O,New Guinea lung,CTV3_Children
+X102P,Paprika splitters' lung,CTV3_Children
+X102Q,Pyrethrum alveolitis,CTV3_Children
+X102R,Rodent handlers' lung,CTV3_Children
+X102S,Sewage workers' lung,CTV3_Children
+X102T,Summer-type hypersensitivity pneumonitis,CTV3_Children
+X102U,Vineyard sprayers' lung,CTV3_Children
+X102j,Cryptogenic organising pneumonitis,CTV3Map_Code_And_Term
+X102j,Cryptogenic organising pneumonitis,CTV3Map_Code_Only
+X102k,"Seasonal crypt organising pneumonia, biochemical cholestasis",CTV3_Children
+X102u,Pulmonary fibrosis,CTV3Map_Code_And_Term
+X102v,Usual interstitial pneumonitis,CTV3Map_Code_And_Term
+X102v,Usual interstitial pneumonitis,CTV3Map_Code_Only
+X102w,Desquamative interstitial pneumonitis,CTV3_Children
+X102x,Lymphoid interstitial pneumonitis,CTV3_Children
+X102y,Giant cell interstitial pneumonitis,CTV3_Children
+X102z,Bronchiolitis obliterans with usual interstitial pneumonitis,CTV3_Children
+X1030,Toxic diffuse interstitial pulmonary fibrosis,CTV3_Children
+X1031,Drug-induced diffuse interstitial pulmonary fibrosis,CTV3_Children
+X1032,Localised pulmonary fibrosis,CTV3_Children
+X1033,Mediastinal radiation fibrosis,CTV3_Children
+X1034,Pneumonitis of non-infectious cause,High_Level_SNOMED
+X1035,Cholesterol pneumonia,High_Level_SNOMED
+X1038,Lupus pneumonia,High_Level_SNOMED
+X103A,Toxic pneumonitis,High_Level_SNOMED
+X103G,Radiation-induced fibrous mediastinitis,CTV3_Children
+X103W,Simple pneumoconiosis,CTV3_Children
+X103X,Complicated pneumoconiosis,CTV3Map_Code_And_Term
+X103Y,Rheumatoid pneumoconiosis,CTV3Map_Code_And_Term
+X103Y,Rheumatoid pneumoconiosis,CTV3Map_Code_Only
+X103Z,Bentonite pneumoconiosis,CTV3_Children
+X103a,Erionite pneumoconiosis,CTV3_Children
+X103b,Kaolin pneumoconiosis,CTV3_Children
+X103c,Metal pneumoconiosis,CTV3_Children
+X103d,Antimony pneumoconiosis,CTV3_Children
+X103e,Argyro-siderosis,CTV3_Children
+X103f,Barium pneumoconiosis,CTV3_Children
+X103h,Subacute berylliosis,CTV3_Children
+X103i,Chronic berylliosis,CTV3_Children
+X103j,Cerium pneumoconiosis,CTV3_Children
+X103k,Hard metal pneumoconiosis,CTV3_Children
+X103l,Nickel pneumoconiosis,CTV3_Children
+X103m,Thorium pneumoconiosis,CTV3_Children
+X103n,Zirconium pneumoconiosis,CTV3_Children
+X103o,Mica pneumoconiosis,CTV3_Children
+X103p,Mixed mineral dust pneumoconiosis,CTV3_Children
+X103q,Liparosis,CTV3_Children
+X103r,Slate pneumoconiosis,CTV3_Children
+X103s,Diatomite pneumoconiosis,CTV3_Children
+X103u,Subacute silicosis,CTV3_Children
+X103v,Chronic silicosis,CTV3_Children
+X103w,Silicotuberculosis,CTV3_Children
+X103x,Wollastonite pneumoconiosis,CTV3_Children
+X1043,Stage 1 pulmonary sarcoidosis,CTV3_Children
+X1044,Stage 2 pulmonary sarcoidosis,CTV3_Children
+X1045,Stage 3 pulmonary sarcoidosis,CTV3_Children
+X1046,Stage 4 pulmonary sarcoidosis,CTV3_Children
+X1047,Endobronchial sarcoidosis,CTV3_Children
+X1048,Necrotising sarcoid granulomatosis,CTV3_Children
+X1049,Sarcoid pulmonary calcification,CTV3_Children
+X104B,Grain fever,High_Level_SNOMED
+X104C,Humidifier fever,High_Level_SNOMED
+X309R,Cystic fibrosis of pancreas,High_Level_SNOMED
+X701k,Fibrosing alveolitis associated with rheumatoid arthritis,CTV3Map_Code_And_Term
+X701k,Fibrosing alveolitis associated with rheumatoid arthritis,CTV3Map_Code_Only
+X70Eg,Pneumonitis due to fetal aspiration,High_Level_SNOMED
+X70RL,Chronic pulmonary histoplasmosis capsulati,QOF
+XE0YM,Purulent chronic bronchitis,CTV3Map_Code_And_Term
+XE0YN,Bullous emphysema with collapse,CTV3Map_Code_And_Term
+XE0YO,Atrophic (senile) emphysema,CTV3Map_Code_And_Term
+XE0YO,Atrophic (senile) emphysema,CTV3Map_Code_Only
+XE0YP,Other emphysema NOS,CTV3Map_Code_And_Term
+XE0YY,Lung disease due to external agents,CTV3Map_Code_Only
+XE0Ya,Post-inflammatory pulmonary fibrosis,CTV3Map_Code_And_Term
+XE0Ya,Post-inflammatory pulmonary fibrosis,CTV3Map_Code_Only
+XE0Yb,Cryptogenic fibrosing alveolitis,CTV3Map_Code_And_Term
+XE0Yb,Cryptogenic fibrosing alveolitis,CTV3Map_Code_Only
+XE0ZN,Chronic: [bronchitis NOS] or [tracheobronchitis],CTV3_Children
+XE0ZV,"(Extrin allerg alveol)/(farm lung)/(pneumonitis, allerg NOS)",CTV3_Children
+XE0ZX,(Asbestosis) or (byssinosis) or (pleural plaque disease),High_Level_SNOMED
+XE0ZZ,(Pneumoconiosis NOS) or (siderosis),CTV3_Children
+XE0Zf,Chronic chemical resp. disease,High_Level_SNOMED
+XE0Zh,Chemical resp. disease NOS,High_Level_SNOMED
+XE0Zr,Idiopath. fibrosing alveolitis (& Hamman-Rich syndrome),CTV3_Children
+XE1NO,(Congenital resp anomalies NOS) or (bronchiectasis - congen),High_Level_SNOMED
+XE1ep,Other specified perinatal chronic respiratory disease,CTV3Map_Code_And_Term
+XE2Pp,History of chronic obstructive pulmonary disease,CTV3Map_Code_And_Term
+XE2Pp,History of chronic obstructive pulmonary disease,CTV3Map_Code_Only
+XM1Qc,Tension pneumatocele,CTV3Map_Code_Only
+XSC3p,Complication of transplanted lung,CTV3Map_Code_And_Term
+Xa08A,Chronic pulmonary insufficiency of prematurity,CTV3_Children
+Xa0BC,Pulmonary fibroplasia,CTV3Map_Code_Only
+Xa0Qe,Congenital hypoplasia of lung,CTV3_Children
+Xa0Qi,Secondary pulmonary hypoplasia,CTV3_Children
+Xa0Qj,Pulmonary hypoplasia associated with short gestation,CTV3_Children
+Xa0Tw,Primary pulmonary hypoplasia,CTV3_Children
+Xa35l,Acute infective exacerbation chronic obstruct airway disease,CTV3_Children
+Xa9Bw,Pneumoconiosis,CTV3Map_Code_And_Term
+Xa9Bw,Pneumoconiosis,CTV3Map_Code_Only
+Xa9Bx,Radiation pneumonitis,High_Level_SNOMED
+XaBDb,Cystic fibrosis with other manifestations,CTV3Map_Code_And_Term
+XaBDb,Cystic fibrosis with other manifestations,CTV3Map_Code_Only
+XaEIV,Mild chronic obstructive pulmonary disease,CTV3Map_Code_And_Term
+XaEIW,Moderate chronic obstructive pulmonary disease,CTV3Map_Code_And_Term
+XaEIY,Severe chronic obstructive pulmonary disease,CTV3Map_Code_And_Term
+XaEKI,Flax-dressers' disease,CTV3_Children
+XaIND,End stage chronic obstructive airways disease,CTV3Map_Code_And_Term
+XaIQT,Chronic obstructive pulmonary disease monitoring,CTV3Map_Code_And_Term
+XaIQg,Interstitial pulmonary emphysema,CTV3Map_Code_And_Term
+XaIQg,Interstitial pulmonary emphysema,CTV3Map_Code_Only
+XaIQh,Mediastinal emphysema,QOF
+XaIRO,Chronic obstructive pulmonary disease monitoring due,CTV3Map_Code_And_Term
+XaIUt,COPD self-management plan given,CTV3Map_Code_And_Term
+XaIes,Chronic obstructive pulmonary disease follow-up,CTV3Map_Code_And_Term
+XaIes,Chronic obstructive pulmonary disease follow-up,CTV3Map_Code_Only
+XaIet,Chronic obstructive pulmonary disease annual review,CTV3Map_Code_And_Term
+XaIu7,Chronic obstructive pulmonary disease monitoring by nurse,CTV3Map_Code_And_Term
+XaIu8,Chronic obstructive pulmonary disease monitoring by doctor,CTV3Map_Code_And_Term
+XaJ4k,Excepted from COPD quality indicators: Patient unsuitable,QOF
+XaJFu,Admit COPD emergency,CTV3Map_Code_And_Term
+XaJYf,Chronic obstructive pulmonary disease clini management plan,CTV3Map_Code_And_Term
+XaJlS,Chronic obstructive pulmonary disease monitoring admin,CTV3Map_Code_And_Term
+XaJlT,Chronic obstructive pulmonary disease monitoring 1st letter,CTV3Map_Code_And_Term
+XaJlU,Chronic obstructive pulmonary disease monitoring 2nd letter,CTV3Map_Code_And_Term
+XaJlV,Chronic obstructive pulmonary disease monitoring 3rd letter,CTV3Map_Code_And_Term
+XaJlW,Chronic obstructive pulmonary disease monitoring verb invite,CTV3Map_Code_And_Term
+XaJlY,Chronic obstructive pulmonary disease monitor phone invite,CTV3Map_Code_And_Term
+XaK8Q,Chronic obstructive pulmonary disease finding,QOF
+XaK8R,COPD accident and emergency attendance since last visit,CTV3Map_Code_And_Term
+XaK8S,Emergency COPD admission since last appointment,CTV3Map_Code_And_Term
+XaK8U,Number of COPD exacerbations in past year,CTV3Map_Code_And_Term
+XaKv8,Chronic obstructive pulmonary disease disturbs sleep,CTV3Map_Code_And_Term
+XaKv9,Chronic obstructive pulmonary disease does not disturb sleep,CTV3Map_Code_And_Term
+XaKzy,Multiple COPD emergency hospital admissions,CTV3Map_Code_And_Term
+XaL2O,"Pneumonitis, unspecified",High_Level_SNOMED
+XaLcH,Single lobe lung transplant,CTV3_Children
+XaLqj,Health education - chronic obstructive pulmonary disease,CTV3Map_Code_And_Term
+XaMzI,Cystic fibrosis related diabetes mellitus,QOF
+XaN4a,Very severe chronic obstructive pulmonary disease,CTV3Map_Code_And_Term
+XaO5l,Chronic type 1 respiratory failure,CTV3Map_Code_And_Term
+XaO5m,Chronic type 2 respiratory failure,CTV3Map_Code_And_Term
+XaOYV,Recurrent pulmonary embolism,QOF
+XaPZH,COPD patient unsuitable for pulmonary rehabilitation,CTV3Map_Code_And_Term
+XaPZH,COPD patient unsuitable for pulmonary rehabilitation,CTV3Map_Code_Only
+XaPls,Referred for COPD structured smoking assessment,CTV3Map_Code_And_Term
+XaPls,Referred for COPD structured smoking assessment,CTV3Map_Code_Only
+XaPlu,COPD structured smoking assessment declined,CTV3Map_Code_And_Term
+XaPlu,COPD structured smoking assessment declined,CTV3Map_Code_Only
+XaPzu,At risk of chronic obstructive pulmonary diseas exacerbation,CTV3Map_Code_And_Term
+XaQvd,Cystic fibrosis annual review,CTV3Map_Code_And_Term
+XaRCG,Step down change in COPD management plan,CTV3_Children
+XaRCH,Step up change in COPD management plan,CTV3_Children
+XaREX,Arthropathy in cystic fibrosis,CTV3Map_Code_And_Term
+XaREZ,Cystic fibrosis with distal intestinal obstruction syndrome,CTV3Map_Code_And_Term
+XaREa,Liver disease due to cystic fibrosis,CTV3Map_Code_And_Term
+XaREd,Fibrosing colonopathy,CTV3Map_Code_And_Term
+XaW9D,Issue of chronic obstructive pulmonary disease rescue pack,CTV3Map_Code_And_Term
+XaXCa,Chronic obstructive pulmonary disease 3 monthly review,CTV3Map_Code_And_Term
+XaXCb,Chronic obstructive pulmonary disease 6 monthly review,CTV3Map_Code_And_Term
+XaXi9,Cystic fibrosis related cirrhosis,CTV3Map_Code_And_Term
+XaXlE,Respiratory bronchiolitis associated interstitial lung dis,High_Level_SNOMED
+XaXlF,Interstitial lung disease due to collagen vascular disease,CTV3Map_Code_And_Term
+XaXlJ,Interstitial lung disease due to connective tissue disease,CTV3Map_Code_And_Term
+XaXnt,GP OOH service notified of COPD care plan,CTV3Map_Code_And_Term
+XaXzy,Preferred place of care for next exacerbation of COPD,CTV3Map_Code_And_Term
+XaY05,Chronic obstructiv pulmonary disease medication optimisation,CTV3Map_Code_And_Term
+XaY0w,Referral to COPD community nursing team,CTV3Map_Code_And_Term
+XaYR1,Bronchiolitis obliterans syndrome after lung transplantation,CTV3Map_Code_And_Term
+XaYZO,COPD self-management plan review,CTV3Map_Code_And_Term
+XaYbA,COPD self-management plan agreed,CTV3Map_Code_And_Term
+XaYby,Hantavirus pulmonary syndrome,High_Level_SNOMED
+XaYuZ,Chronic obstructve pulmonry disease rescue pack not indicatd,CTV3Map_Code_And_Term
+XaZ6U,On chronic obstructive pulmonary disease supprtv cre pathway,CTV3Map_Code_And_Term
+XaZ6U,On chronic obstructive pulmonary disease supprtv cre pathway,CTV3Map_Code_Only
+XaZ8t,Has chronic obstructive pulmonary disease care plan,CTV3Map_Code_And_Term
+XaZd1,Acute non-infective exacerbation of COPD,CTV3_Children
+XaZee,Chronic obstructive pulmonary disease care pathway,CTV3Map_Code_And_Term
+XaZoz,Seen in chronic obstructive pulmonary disease clinic,CTV3Map_Code_And_Term
+XaZp7,Chronic obstructive pulmonary disease rescue pack declined,CTV3Map_Code_And_Term
+XaZp8,Chronic obstructive pulmon dis wr self managem plan declined,CTV3Map_Code_And_Term
+XaZr7,Exacerbation of cystic fibrosis,CTV3Map_Code_And_Term
+Xaa7C,Eosinophilic bronchitis,QOF
+Xaam4,Chronic obstruct pulmonary disease management plan declined,CTV3Map_Code_And_Term
+XaavA,Shared care chronic obstructive pulmonary disease monitoring,CTV3_Children
+Xabud,H/O: bronchiectasis,CTV3Map_Code_And_Term
+Xac33,Asthma-chronic obstructive pulmonary disease overlap syndrom,CTV3Map_Code_And_Term
+Xac8s,Telehealth chronic obstructive pulmonary disease monitoring,CTV3Map_Code_And_Term
+XafhZ,COPD monitoring email invitation,QOF
+Xafhe,COPD monitring short message service text message invitation,QOF
+Xafir,COPD monitoring SMS text message first invitation,QOF
+Xafit,COPD monitoring SMS text message second invitation,QOF
+Xafiu,COPD monitoring SMS text message third invitation,QOF
+Y1f1b,Chronic obstructive pulmonary disease monitoring invitation,QOF
+Y1f94,Quality and Outcomes Framework chronic obstructive pulmonary disease quality indicator-related care invitation (procedure),QOF
+Y1f95,Excepted from chronic obstructive pulmonary disease quality indicators - service unavailable (finding),QOF
+Y2708,Cystic fibrosis screening test,CTV3_Children
+Y2710,Cystic fibrosis positive,CTV3_Children

--- a/tests/fixtures/codelists/opensafely-covid-identification.csv
+++ b/tests/fixtures/codelists/opensafely-covid-identification.csv
@@ -1,0 +1,3 @@
+icd10_code,name
+U071,covid19 virus identified
+U072,covid19 virus not identified

--- a/tests/fixtures/codelists/opensafely-current-asthma.csv
+++ b/tests/fixtures/codelists/opensafely-current-asthma.csv
@@ -1,0 +1,317 @@
+CTV3ID,CTV3PreferredTermDesc,CTV3Source
+173A.,Exercise-induced asthma,CTV3Map_Code_And_Term
+173A.,Exercise-induced asthma,CTV3Map_Code_Only
+173A.,Exercise-induced asthma,QOF
+663N.,Asthma disturbing sleep,CTV3Map_Code_And_Term
+663N.,Asthma disturbing sleep,QOF
+663N0,Asthma causing night waking,CTV3Map_Code_And_Term
+663N0,Asthma causing night waking,QOF
+663N1,Asthma disturbs sleep weekly,CTV3Map_Code_And_Term
+663N1,Asthma disturbs sleep weekly,QOF
+663N2,Asthma disturbs sleep frequently,CTV3Map_Code_And_Term
+663N2,Asthma disturbs sleep frequently,QOF
+663O.,Asthma not disturbing sleep,QOF
+663O0,Asthma never disturbs sleep,CTV3Map_Code_And_Term
+663O0,Asthma never disturbs sleep,QOF
+663P.,Asthma limiting activities,CTV3Map_Code_And_Term
+663P.,Asthma limiting activities,QOF
+663Q.,Asthma not limiting activities,QOF
+663U.,Asthma management plan given,CTV3Map_Code_And_Term
+663V.,Asthma severity,CTV3Map_Code_And_Term
+663V0,Occasional asthma,CTV3Map_Code_And_Term
+663V0,Occasional asthma,QOF
+663V1,Mild asthma,CTV3Map_Code_And_Term
+663V1,Mild asthma,QOF
+663V2,Moderate asthma,CTV3Map_Code_And_Term
+663V2,Moderate asthma,QOF
+663V3,Severe asthma,CTV3Map_Code_And_Term
+663V3,Severe asthma,QOF
+663W.,Asthma prophylactic medication used,CTV3_Children
+663d.,Emergency asthma admission since last appointment,CTV3Map_Code_And_Term
+663e.,Asthma restricts exercise,CTV3Map_Code_And_Term
+663e.,Asthma restricts exercise,QOF
+663e0,Asthma sometimes restricts exercise,CTV3Map_Code_And_Term
+663e0,Asthma sometimes restricts exercise,QOF
+663e1,Asthma severely restricts exercise,CTV3Map_Code_And_Term
+663e1,Asthma severely restricts exercise,QOF
+663f.,Asthma never restricts exercise,CTV3Map_Code_And_Term
+663f.,Asthma never restricts exercise,QOF
+679J.,Health education - asthma,High_Level_SNOMED
+8791.,Further asthma - drug prevention,CTV3Map_Code_And_Term
+8793.,Asthma control step 0,High_Level_SNOMED
+8794.,Asthma control step 1,CTV3Map_Code_And_Term
+8795.,Asthma control step 2,CTV3Map_Code_And_Term
+8796.,Asthma control step 3,CTV3Map_Code_And_Term
+8797.,Asthma control step 4,CTV3Map_Code_And_Term
+8798.,Asthma control step 5,CTV3Map_Code_And_Term
+8H2P.,"Emergency admission, asthma",CTV3Map_Code_And_Term
+8H2P.,"Emergency admission, asthma",QOF
+9OJ1.,Attends asthma monitoring,CTV3Map_Code_And_Term
+9OJ3.,Asthma monitor offer default,High_Level_SNOMED
+9OJ4.,Asthma monitoring call first letter,QOF
+9OJ5.,Asthma monitoring call second letter,QOF
+9OJ6.,Asthma monitoring call third letter,QOF
+9OJ7.,Asthma monitoring call verbal invite,QOF
+9OJ8.,Asthma monitoring call telephone invite,QOF
+9OJ9.,Asthma monitoring deleted,High_Level_SNOMED
+9OJA.,Asthma monitored (& check done),QOF
+9Q21.,Patient in asthma study,High_Level_SNOMED
+H3120,Chronic asthmatic bronchitis,CTV3Map_Code_And_Term
+H3120,Chronic asthmatic bronchitis,CTV3Map_Code_Only
+H3120,Chronic asthmatic bronchitis,QOF
+H33..,Asthma,CTV3Map_Code_And_Term
+H33..,Asthma,CTV3Map_Code_Only
+H33..,Asthma,QOF
+H330.,Asthma: [extrins - atop][allerg][pollen][childh][+ hay fev],CTV3_Children
+H330.,Asthma: [extrins - atop][allerg][pollen][childh][+ hay fev],QOF
+H3300,(Hay fever + asthma) or (extr asthma without status asthmat),CTV3_Children
+H3300,(Hay fever + asthma) or (extr asthma without status asthmat),QOF
+H3301,Extrins asthma with: [asthma attack] or [status asthmaticus],CTV3_Children
+H3301,Extrins asthma with: [asthma attack] or [status asthmaticus],QOF
+H330z,Extrinsic asthma NOS,CTV3Map_Code_And_Term
+H330z,Extrinsic asthma NOS,QOF
+H331.,(Intrinsic asthma) or (late onset asthma),CTV3_Children
+H331.,(Intrinsic asthma) or (late onset asthma),QOF
+H3310,Intrinsic asthma without status asthmaticus,CTV3Map_Code_And_Term
+H3310,Intrinsic asthma without status asthmaticus,QOF
+H3311,Intrins asthma with: [asthma attack] or [status asthmaticus],CTV3_Children
+H3311,Intrins asthma with: [asthma attack] or [status asthmaticus],QOF
+H331z,Intrinsic asthma NOS,CTV3Map_Code_And_Term
+H331z,Intrinsic asthma NOS,CTV3Map_Code_Only
+H331z,Intrinsic asthma NOS,QOF
+H332.,Mixed asthma,CTV3_Children
+H332.,Mixed asthma,QOF
+H33z.,Asthma unspecified,CTV3Map_Code_And_Term
+H33z.,Asthma unspecified,CTV3Map_Code_Only
+H33z.,Asthma unspecified,QOF
+H33z0,(Severe asthma attack) or (status asthmaticus NOS),CTV3_Children
+H33z0,(Severe asthma attack) or (status asthmaticus NOS),QOF
+H33z1,Asthma attack (& NOS),CTV3_Children
+H33z1,Asthma attack (& NOS),QOF
+H33z2,Late onset asthma,CTV3_Children
+H33z2,Late onset asthma,QOF
+H33zz,(Asthma:[exerc ind][allerg NEC][NOS]) or (allerg bronch NEC),CTV3_Children
+H33zz,(Asthma:[exerc ind][allerg NEC][NOS]) or (allerg bronch NEC),QOF
+H47y0,Detergent asthma,CTV3Map_Code_And_Term
+H47y0,Detergent asthma,QOF
+Ua1AX,Brittle asthma,CTV3Map_Code_And_Term
+Ua1AX,Brittle asthma,QOF
+X101u,Late onset asthma,CTV3Map_Code_And_Term
+X101u,Late onset asthma,CTV3Map_Code_Only
+X101u,Late onset asthma,QOF
+X101x,Allergic asthma,CTV3Map_Code_And_Term
+X101x,Allergic asthma,CTV3Map_Code_Only
+X101x,Allergic asthma,QOF
+X101y,Extrinsic asthma with asthma attack,CTV3Map_Code_And_Term
+X101y,Extrinsic asthma with asthma attack,CTV3Map_Code_Only
+X101y,Extrinsic asthma with asthma attack,QOF
+X101z,Allergic asthma NEC,CTV3Map_Code_And_Term
+X101z,Allergic asthma NEC,CTV3Map_Code_Only
+X101z,Allergic asthma NEC,QOF
+X1020,Hay fever with asthma,CTV3Map_Code_And_Term
+X1020,Hay fever with asthma,CTV3Map_Code_Only
+X1020,Hay fever with asthma,QOF
+X1021,Allergic non-atopic asthma,CTV3_Children
+X1021,Allergic non-atopic asthma,QOF
+X1022,Intrinsic asthma with asthma attack,CTV3Map_Code_And_Term
+X1022,Intrinsic asthma with asthma attack,CTV3Map_Code_Only
+X1022,Intrinsic asthma with asthma attack,QOF
+X1023,Drug-induced asthma,CTV3_Children
+X1023,Drug-induced asthma,QOF
+X1024,Aspirin-sensitive asthma with nasal polyps,CTV3_Children
+X1024,Aspirin-sensitive asthma with nasal polyps,QOF
+X1025,Occupational asthma,CTV3Map_Code_And_Term
+X1025,Occupational asthma,QOF
+X1026,Baker's asthma,CTV3_Children
+X1026,Baker's asthma,QOF
+X1027,Colophony asthma,CTV3_Children
+X1027,Colophony asthma,QOF
+X1028,Grain worker's asthma,CTV3_Children
+X1028,Grain worker's asthma,QOF
+X1029,Sulphite-induced asthma,CTV3_Children
+X1029,Sulphite-induced asthma,QOF
+X102D,Status asthmaticus,CTV3_Children
+X102D,Status asthmaticus,QOF
+X102G,Asthmatic pulmonary eosinophilia,QOF
+XE0YQ,Allergic atopic asthma,CTV3Map_Code_And_Term
+XE0YQ,Allergic atopic asthma,CTV3Map_Code_Only
+XE0YQ,Allergic atopic asthma,QOF
+XE0YR,Extrinsic asthma without status asthmaticus,CTV3Map_Code_And_Term
+XE0YR,Extrinsic asthma without status asthmaticus,CTV3Map_Code_Only
+XE0YR,Extrinsic asthma without status asthmaticus,QOF
+XE0YS,Extrinsic asthma with status asthmaticus,CTV3Map_Code_And_Term
+XE0YS,Extrinsic asthma with status asthmaticus,CTV3Map_Code_Only
+XE0YS,Extrinsic asthma with status asthmaticus,QOF
+XE0YT,Non-allergic asthma,CTV3_Children
+XE0YT,Non-allergic asthma,QOF
+XE0YU,Intrinsic asthma with status asthmaticus,CTV3Map_Code_And_Term
+XE0YU,Intrinsic asthma with status asthmaticus,CTV3Map_Code_Only
+XE0YU,Intrinsic asthma with status asthmaticus,QOF
+XE0YV,Status asthmaticus NOS,CTV3Map_Code_And_Term
+XE0YV,Status asthmaticus NOS,CTV3Map_Code_Only
+XE0YV,Status asthmaticus NOS,QOF
+XE0YW,Asthma attack,CTV3Map_Code_And_Term
+XE0YW,Asthma attack,CTV3Map_Code_Only
+XE0YW,Asthma attack,QOF
+XE0YX,Asthma NOS,CTV3Map_Code_And_Term
+XE0YX,Asthma NOS,CTV3Map_Code_Only
+XE0YX,Asthma NOS,QOF
+XE0ZP,Extrinsic asthma - atopy (& pollen),CTV3_Children
+XE0ZP,Extrinsic asthma - atopy (& pollen),QOF
+XE0ZR,Asthma: [intrinsic] or [late onset],CTV3_Children
+XE0ZR,Asthma: [intrinsic] or [late onset],QOF
+XE0ZT,Asthma: [NOS] or [attack],CTV3_Children
+XE0ZT,Asthma: [NOS] or [attack],QOF
+XE2Nb,Asthma monitoring check done,CTV3Map_Code_And_Term
+XE2Nb,Asthma monitoring check done,CTV3Map_Code_Only
+XE2Nb,Asthma monitoring check done,QOF
+XM0s2,Asthma attack NOS,CTV3Map_Code_And_Term
+XM0s2,Asthma attack NOS,CTV3Map_Code_Only
+XM0s2,Asthma attack NOS,QOF
+XM1Xb,Asthma monitoring,CTV3Map_Code_And_Term
+Xa0lZ,Asthmatic bronchitis,CTV3Map_Code_Only
+Xa0lZ,Asthmatic bronchitis,QOF
+Xa1hD,Exacerbation of asthma,CTV3Map_Code_And_Term
+Xa1hD,Exacerbation of asthma,QOF
+Xa8Hn,Asthma control steps,High_Level_SNOMED
+Xa9zf,Acute asthma,CTV3_Children
+Xa9zf,Acute asthma,QOF
+XaBAQ,Recent asthma management,CTV3_Children
+XaBU2,Asthma monitoring call,High_Level_SNOMED
+XaBU3,Asthma monitoring status,High_Level_SNOMED
+XaDvK,Asthma - currently active,CTV3Map_Code_And_Term
+XaDvK,Asthma - currently active,QOF
+XaDvL,Asthma - currently dormant,High_Level_SNOMED
+XaIIW,Asthma accident and emergency attendance since last visit,CTV3Map_Code_And_Term
+XaIIX,Asthma treatment compliance satisfactory,CTV3Map_Code_And_Term
+XaIIY,Asthma treatment compliance unsatisfactory,CTV3Map_Code_And_Term
+XaIIZ,Asthma daytime symptoms,CTV3Map_Code_And_Term
+XaIIZ,Asthma daytime symptoms,QOF
+XaINZ,Asthma causes night symptoms 1 to 2 times per month,CTV3Map_Code_And_Term
+XaINZ,Asthma causes night symptoms 1 to 2 times per month,QOF
+XaINa,Asthma never causes daytime symptoms,CTV3Map_Code_And_Term
+XaINa,Asthma never causes daytime symptoms,QOF
+XaINb,Asthma causes daytime symptoms 1 to 2 times per month,CTV3Map_Code_And_Term
+XaINb,Asthma causes daytime symptoms 1 to 2 times per month,QOF
+XaINc,Asthma causes daytime symptoms 1 to 2 times per week,CTV3Map_Code_And_Term
+XaINc,Asthma causes daytime symptoms 1 to 2 times per week,QOF
+XaINd,Asthma causes daytime symptoms most days,CTV3Map_Code_And_Term
+XaINd,Asthma causes daytime symptoms most days,QOF
+XaINf,Asthma limits walking up hills or stairs,CTV3Map_Code_And_Term
+XaINf,Asthma limits walking up hills or stairs,QOF
+XaINg,Asthma limits walking on the flat,CTV3Map_Code_And_Term
+XaINg,Asthma limits walking on the flat,QOF
+XaINh,Number of asthma exacerbations in past year,CTV3Map_Code_And_Term
+XaIOV,Asthma finding,High_Level_SNOMED
+XaIQ4,Change in asthma management plan,CTV3Map_Code_And_Term
+XaIQ4,Change in asthma management plan,QOF
+XaIQD,Step up change in asthma management plan,CTV3Map_Code_And_Term
+XaIQD,Step up change in asthma management plan,QOF
+XaIQE,Step down change in asthma management plan,CTV3Map_Code_And_Term
+XaIQE,Step down change in asthma management plan,QOF
+XaIR3,Absent from work or school due to asthma,CTV3Map_Code_And_Term
+XaIR3,Absent from work or school due to asthma,QOF
+XaIRN,Asthma monitoring due,High_Level_SNOMED
+XaIeq,Asthma annual review,CTV3Map_Code_And_Term
+XaIeq,Asthma annual review,QOF
+XaIer,Asthma follow-up,CTV3Map_Code_And_Term
+XaIer,Asthma follow-up,QOF
+XaIfK,Asthma medication review,CTV3Map_Code_And_Term
+XaIfK,Asthma medication review,QOF
+XaIoE,Asthma night-time symptoms,CTV3Map_Code_And_Term
+XaIoE,Asthma night-time symptoms,QOF
+XaIu5,Asthma monitoring by nurse,CTV3Map_Code_And_Term
+XaIu5,Asthma monitoring by nurse,QOF
+XaIu6,Asthma monitoring by doctor,CTV3Map_Code_And_Term
+XaIu6,Asthma monitoring by doctor,QOF
+XaIuG,Asthma confirmed,CTV3Map_Code_And_Term
+XaIuG,Asthma confirmed,QOF
+XaIww,Asthma trigger,High_Level_SNOMED
+XaJFG,Aspirin-induced asthma,CTV3Map_Code_And_Term
+XaJFG,Aspirin-induced asthma,QOF
+XaJYe,Asthma clinical management plan,CTV3Map_Code_And_Term
+XaKdk,Work aggravated asthma,CTV3Map_Code_And_Term
+XaKdk,Work aggravated asthma,QOF
+XaLIm,Asthma trigger - respiratory infection,CTV3Map_Code_And_Term
+XaLIn,Asthma trigger - seasonal,CTV3Map_Code_And_Term
+XaLIr,Asthma trigger - animals,CTV3Map_Code_And_Term
+XaLJS,Asthma trigger - cold air,CTV3Map_Code_And_Term
+XaLJT,Asthma trigger - damp,CTV3Map_Code_And_Term
+XaLJU,Asthma trigger - emotion,CTV3Map_Code_And_Term
+XaLPE,Nocturnal asthma,CTV3_Children
+XaLPE,Nocturnal asthma,QOF
+XaNKw,Royal College of Physicians asthma assessment,CTV3Map_Code_And_Term
+XaNKw,Royal College of Physicians asthma assessment,CTV3Map_Code_Only
+XaObi,Asthma trigger - airborne dust,CTV3Map_Code_And_Term
+XaObj,Asthma trigger - exercise,CTV3Map_Code_And_Term
+XaObk,Asthma trigger - pollen,CTV3Map_Code_And_Term
+XaObl,Asthma trigger - tobacco smoke,CTV3Map_Code_And_Term
+XaObm,Asthma trigger - warm air,CTV3Map_Code_And_Term
+XaQHq,Asthma control test,CTV3Map_Code_And_Term
+XaQig,Asthma control questionnaire,CTV3Map_Code_And_Term
+XaQih,Mini asthma quality of life questionnaire,CTV3Map_Code_And_Term
+XaQij,Under care of asthma specialist nurse,CTV3Map_Code_And_Term
+XaR8K,Did not attend asthma review,High_Level_SNOMED
+XaRFi,Patient has a written asthma personal action plan,CTV3Map_Code_And_Term
+XaRFj,Health education - asthma self management,CTV3Map_Code_And_Term
+XaRFk,Health education - structured asthma discussion,CTV3Map_Code_And_Term
+XaRFl,Health education - structured patient focused asthma discuss,CTV3Map_Code_And_Term
+XaX3n,Asthma review using Roy Colleg of Physicians three questions,CTV3Map_Code_And_Term
+XaX3n,Asthma review using Roy Colleg of Physicians three questions,QOF
+XaXZm,Asthma causes night time symptoms 1 to 2 times per week,CTV3Map_Code_And_Term
+XaXZm,Asthma causes night time symptoms 1 to 2 times per week,QOF
+XaXZp,Asthma causes symptoms most nights,CTV3Map_Code_And_Term
+XaXZp,Asthma causes symptoms most nights,QOF
+XaXZs,Asthma limits activities 1 to 2 times per month,CTV3Map_Code_And_Term
+XaXZs,Asthma limits activities 1 to 2 times per month,QOF
+XaXZu,Asthma limits activities 1 to 2 times per week,CTV3Map_Code_And_Term
+XaXZu,Asthma limits activities 1 to 2 times per week,QOF
+XaXZx,Asthma limits activities most days,CTV3Map_Code_And_Term
+XaXZx,Asthma limits activities most days,QOF
+XaXa0,Royal College Physician asthma assessment 3 question score,CTV3Map_Code_And_Term
+XaY2V,Asthma never causes night symptoms,CTV3Map_Code_And_Term
+XaY2V,Asthma never causes night symptoms,QOF
+XaYZB,Asthma self-management plan review,CTV3Map_Code_And_Term
+XaYZh,Number days absent from school due to asthma in past 6 month,CTV3Map_Code_And_Term
+XaYZh,Number days absent from school due to asthma in past 6 month,QOF
+XaYb8,Asthma self-management plan agreed,CTV3Map_Code_And_Term
+XaYja,Asthma trigger - wind,High_Level_SNOMED
+XaYpF,Asthma trigger - perfume,High_Level_SNOMED
+Xaa7B,Chronic asthma with fixed airflow obstruction,CTV3Map_Code_And_Term
+Xaa7B,Chronic asthma with fixed airflow obstruction,QOF
+Xaa7Q,No asthma trigger identified by subject,High_Level_SNOMED
+Xabiu,Asthma monitorng invit SMS (short message servce) txt messge,QOF
+Xabj3,Asthma monitoring invitation email,QOF
+Xac33,Asthma-chronic obstructive pulmonary disease overlap syndrom,QOF
+Xac8r,Telehealth asthma monitoring,CTV3_Children
+XacLz,Asthma monitoring SMS text message 1st invitation,QOF
+XacM0,Asthma monitoring SMS text message 2nd invitation,QOF
+XacM1,Asthma monitoring SMS text message 3rd invitation,QOF
+XacXj,At risk of severe asthma exacerbation,High_Level_SNOMED
+Xafdj,Acute severe exacerbation of asthma,CTV3Map_Code_And_Term
+Xafdj,Acute severe exacerbation of asthma,CTV3Map_Code_Only
+Xafdj,Acute severe exacerbation of asthma,QOF
+Xafdy,Moderate acute exacerbation of asthma,CTV3_Children
+Xafdy,Moderate acute exacerbation of asthma,QOF
+Xafdz,Life threatening acute exacerbation of asthma,CTV3_Children
+Xafdz,Life threatening acute exacerbation of asthma,QOF
+Xaff0,Use of asthma symptom diary,CTV3_Children
+Y0017,Nocturnal Asthma,CTV3_Children
+Y0017,Nocturnal Asthma,QOF
+Y137e,Asthma guidance,CTV3_Children
+Y137f,Indicators - worsening asthma,CTV3_Children
+Y138a,Indicators - asthma attack,CTV3_Children
+Y139b,Asthma guidance,CTV3_Children
+Y139c,Indicators - worsening asthma,CTV3_Children
+Y139d,Indicators - asthma attack,CTV3_Children
+Y13a1,Worsening asthma - preventer inhaler increased dose,CTV3_Children
+Y13a2,Worsening asthma - reliever inhaler increased dose 4 hourly,CTV3_Children
+Y13a3,Worsening asthma - steroid Rescue dose prednisolone,CTV3_Children
+Y13a4,Worsening asthma - steroid Rescue dose prednisolone no. 5mg tabs,CTV3_Children
+Y13a5,Worsening asthma - steroid Rescue dose prednisolone no. days treatment,CTV3_Children
+Y13a7,Peak flow - worsening asthma - less than,CTV3_Children
+Y13a8,Asthma attack - reliever use more frequent than every,CTV3_Children
+Y13a9,Asthma attack - peak flow less than,CTV3_Children
+Y1b24,Acute severe exacerbation of allergic asthma,CTV3_Children
+Y1b24,Acute severe exacerbation of allergic asthma,QOF
+Y1f90,Quality and Outcomes Framework asthma quality indicator-related care invitation (procedure),QOF

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 from requests_mock import mocker
@@ -34,3 +35,8 @@ def test_codelists_update(tmp_path, requests_mock):
     assert (codelist_dir / "project123-codelist456.csv").read_text() == "foo"
     assert not (codelist_dir / "project123-codelist789-version1.csv").exists()
     assert (codelist_dir / "project123-codelist098.csv").read_text() == "bar"
+    manifest = json.loads((codelist_dir / "codelists.json").read_text())
+    assert manifest["files"].keys() == {
+        "project123-codelist456.csv",
+        "project123-codelist098.csv",
+    }

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -47,9 +47,8 @@ def test_codelists_update(tmp_path, requests_mock):
 
 @pytest.fixture
 def codelists_path(tmp_path):
-    shutil.copytree(
-        Path(__file__).parent / "fixtures/codelists", tmp_path / "codelists"
-    )
+    fixture_path = Path(__file__).parent / "fixtures" / "codelists"
+    shutil.copytree(fixture_path, tmp_path / "codelists")
     yield tmp_path
 
 

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -1,6 +1,9 @@
 import json
 import os
+from pathlib import Path
+import shutil
 
+import pytest
 from requests_mock import mocker
 
 from opensafely._vendor import requests
@@ -40,3 +43,39 @@ def test_codelists_update(tmp_path, requests_mock):
         "project123-codelist456.csv",
         "project123-codelist098.csv",
     }
+
+
+@pytest.fixture
+def codelists_path(tmp_path):
+    shutil.copytree(
+        Path(__file__).parent / "fixtures/codelists", tmp_path / "codelists"
+    )
+    yield tmp_path
+
+
+def test_codelists_check(codelists_path):
+    os.chdir(codelists_path)
+    codelists.check()
+
+
+def test_codelists_check_fail_if_list_updated(codelists_path):
+    with open(codelists_path / "codelists/codelists.txt", "a") as f:
+        f.write("\nsomeproject/somelist/someversion")
+    os.chdir(codelists_path)
+    with pytest.raises(SystemExit):
+        codelists.check()
+
+
+def test_codelists_check_fail_if_file_added(codelists_path):
+    codelists_path.joinpath("codelists", "my-new-file.csv").touch()
+    os.chdir(codelists_path)
+    with pytest.raises(SystemExit):
+        codelists.check()
+
+
+def test_codelists_check_fail_if_file_modified(codelists_path):
+    filename = codelists_path / "codelists" / "opensafely-covid-identification.csv"
+    filename.write_text("blah")
+    os.chdir(codelists_path)
+    with pytest.raises(SystemExit):
+        codelists.check()


### PR DESCRIPTION
This adds an `opensafely codelists check` command which verifies that the CSVs in your `codelists` folder match what's specified in `codelists.txt`. It does this by recording what files have been downloaded (and their hashes) in a `codelists.json` file.

There's some temporary code which spots that it's being run in a Github Action and falls back to using the old verification method (which checks against OpenCodelists) so that existing repos don't fail immediately under the new method.

Closes #12