### PR TITLE
fix: Support user-namespaced codelists

### DIFF
--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -170,17 +170,20 @@ def parse_codelist_file(codelists_dir):
         line = line.strip()
         if not line or line.startswith("#"):
             continue
-        project_id, codelist_id, version = line.split("/")
-        url = (
-            f"https://codelists.opensafely.org"
-            f"/codelist/{project_id}/{codelist_id}/{version}/"
-        )
+        tokens = line.split("/")
+        if len(tokens) not in [3, 4]:
+            exit_with_error(
+                f"{line} does not match [project]/[codelist]/[version] "
+                "or user/[username]/[codelist]/[version]"
+            )
+        url = f"https://codelists.opensafely.org/codelist/{line}/"
+        filename = "-".join(tokens[:-1]) + ".csv"
         codelists.append(
             Codelist(
                 id=line,
                 url=url,
                 download_url=f"{url}download.csv",
-                filename=codelists_dir / f"{project_id}-{codelist_id}.csv",
+                filename=codelists_dir / filename,
             )
         )
     return codelists

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -21,7 +21,7 @@ def test_codelists_update(tmp_path, requests_mock):
     (codelist_dir / "project123-codelist456.csv").touch()
     (codelist_dir / "project123-codelist789.csv").touch()
     (codelist_dir / "codelists.txt").write_text(
-        "project123/codelist456/version2\n  \nproject123/codelist098/version1\n"
+        "project123/codelist456/version2\n  \nuser/user123/codelist098/version1\n"
     )
     os.chdir(tmp_path)
     requests_mock.get(
@@ -31,17 +31,17 @@ def test_codelists_update(tmp_path, requests_mock):
     )
     requests_mock.get(
         "https://codelists.opensafely.org/"
-        "codelist/project123/codelist098/version1/download.csv",
+        "codelist/user/user123/codelist098/version1/download.csv",
         text="bar",
     )
     codelists.update()
     assert (codelist_dir / "project123-codelist456.csv").read_text() == "foo"
     assert not (codelist_dir / "project123-codelist789-version1.csv").exists()
-    assert (codelist_dir / "project123-codelist098.csv").read_text() == "bar"
+    assert (codelist_dir / "user-user123-codelist098.csv").read_text() == "bar"
     manifest = json.loads((codelist_dir / "codelists.json").read_text())
     assert manifest["files"].keys() == {
         "project123-codelist456.csv",
-        "project123-codelist098.csv",
+        "user-user123-codelist098.csv",
     }
 
 


### PR DESCRIPTION
Codelists owned by users are at codelists.opensafely.org/codelist/user/[username]/[codelist]/[version].